### PR TITLE
Add branch smoke test workflow for get-iplayer

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,5 +25,9 @@ jobs:
       - name: 🔎 Smoke test get-iplayer
         run: |
           expected_version="$(sed -n 's/^version: "\(.*\)"/\1/p' snap/snapcraft.yaml)"
-          snap run get-iplayer.get-iplayer --version | tee version.txt
+          set +e
+          snap run get-iplayer.get-iplayer 2>&1 | tee version.txt
+          status=$?
+          set -e
+          test "$status" -eq 0 -o "$status" -eq 1
           grep -F "$expected_version" version.txt

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,9 @@
 name: Pull Request
 
 on:
+  push:
+    branches:
+      - "**"
   pull_request:
     branches: [ "**" ]
 
@@ -10,8 +13,17 @@ concurrency:
 
 jobs:
   build:
-    name: 🧪 Build snap on amd64
+    name: 🧪 Build and smoke test snap on amd64
     runs-on: ubuntu-latest
     steps:
       - name: 🧪 Build snap on amd64
         uses: snapcrafters/ci/test-snap-build@main
+
+      - name: 📥 Install built snap
+        run: sudo snap install --dangerous ./*.snap
+
+      - name: 🔎 Smoke test get-iplayer
+        run: |
+          expected_version="$(sed -n 's/^version: "\(.*\)"/\1/p' snap/snapcraft.yaml)"
+          snap run get-iplayer.get-iplayer --version | tee version.txt
+          grep -F "$expected_version" version.txt


### PR DESCRIPTION
## Summary
- run the build workflow on branch pushes as well as pull requests
- install the built snap in CI and smoke test it by invoking get-iplayer directly
- accept the program's expected banner/help exit status while still checking the emitted version string

## Testing
- GitHub Actions run 24691732619 on minnielove2026/get-iplayer passed on branch ci-smoketest
