### PR TITLE
fix: migrate snap to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,16 +4,16 @@ summary: CLI for downloading content from BBC iplayer
 description: |
     Command Line tool for downloading tv and radio programmes from the last 30 days from the BBC iPlayer.
 version: "3.36"
-base: core22
+base: core24
 grade: stable 
 confinement: strict
 
-architectures:
-  - amd64
-  - arm64
-  - armhf
-  - ppc64el
-  - s390x
+platforms:
+  amd64:
+  arm64:
+  armhf:
+  ppc64el:
+  s390x:
 
 # plugs:
 #   etc-get-iplayer-options:


### PR DESCRIPTION
## Summary
- migrate the snap base from core22 to core24
- switch the architecture declaration to core22/core24 `platforms:` syntax

## Context
The current release job fails on non-amd64 architectures while planning remote builds:

`Could not make build plan: build-on architectures in snapcraft.yaml does not match host architecture`

This PR tries the core24/platforms shape to see whether it resolves the release-to-candidate architecture planning failure.

## Validation
- parsed `snap/snapcraft.yaml` with PyYAML
- asserted base is core24 and platforms are amd64, arm64, armhf, ppc64el, s390x
- ran `git diff --check`

@jnsgruk