### PR TITLE
fix: use noble Berkeley DB runtime package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,7 +69,7 @@ parts:
         - libcgi-pm-perl
         - atomicparsley
         - ffmpeg
-        - libdb5.3
+        - libdb5.3t64
         - libpulse0
         - libslang2
         - libglut3.12


### PR DESCRIPTION
## Summary
- Replace Noble-missing `libdb5.3` with `libdb5.3t64` after the armhf release job failed during stage-package resolution.

## Validation
- Parsed `snap/snapcraft.yaml` and asserted `base: core24`, target `platforms`, and updated stage packages.
- Queried Launchpad published binaries for every stage package on Noble across `amd64`, `arm64`, `armhf`, `ppc64el`, and `s390x`; all proposed packages are published for every target architecture.
- Ran `git diff --check`.

Fixes the follow-up failure in https://github.com/snapcrafters/get-iplayer/actions/runs/27022850994/job/79755120907:

```text
Stage package not found in part 'get-iplayer': libdb5.3.
```

@jnsgruk please review.