### PR TITLE
fix: derive Perl library paths in launcher

### DIFF
--- a/snap/local/scripts/launcher
+++ b/snap/local/scripts/launcher
@@ -9,7 +9,22 @@ case "$SNAP_ARCH" in
 esac
 
 export LC_ALL="C.UTF-8"
-export PERL5LIB="$SNAP/usr/lib/$ARCH/perl-base/:$SNAP/usr/lib/$ARCH/perl5/5.34/:$SNAP/usr/share/perl5/:$SNAP/usr/share/perl/5.34/:$SNAP/usr/share/perl/5.34.0/:$SNAP/usr/lib/$ARCH/perl/5.34/"
+
+PERL5LIB_PATHS=(
+    "$SNAP/usr/lib/$ARCH/perl-base"
+    "$SNAP/usr/lib/$ARCH/perl5"/[0-9]*
+    "$SNAP/usr/share/perl5"
+    "$SNAP/usr/share/perl"/[0-9]*
+    "$SNAP/usr/lib/$ARCH/perl"/[0-9]*
+)
+PERL5LIB=""
+for path in "${PERL5LIB_PATHS[@]}"; do
+    if [ -d "$path" ]; then
+        PERL5LIB="${PERL5LIB:+$PERL5LIB:}$path"
+    fi
+done
+export PERL5LIB
+
 export LD_LIBRARY_PATH="$SNAP/usr/lib/$ARCH/blas/:$SNAP/usr/lib/$ARCH/lapack/:$SNAP/usr/lib/$ARCH/pulseaudio/:$LD_LIBRARY_PATH"
 export HOME="$SNAP_USER_COMMON"
 


### PR DESCRIPTION
Fixes the get-iplayer 3.36 core24 candidate startup failure reported in snapcrafters/get-iplayer#21:

https://github.com/snapcrafters/get-iplayer/issues/21#issuecomment-4638019384

Summary:
- Replace hard-coded Perl 5.34 paths in snap/local/scripts/launcher.
- Derive staged Perl library paths from the snap payload at runtime.
- Keep the launcher working across Perl minor-version changes in the base/staged packages.

Testing:
- bash -n snap/local/scripts/launcher
- git diff --check
- Reproduced the candidate failure with the shipped launcher environment:
  Can't locate Encode.pm in @INC ... at get_iplayer line 39.
- Copied the fixed launcher into the extracted amd64 candidate payload and verified get_iplayer starts successfully.
- Built the fixed snap from this branch with snapcraft --destructive-mode in an Ubuntu 24.04 LXD container.
- Installed the locally built snap with snap install --dangerous.
- Verified get-iplayer --helpbasic starts under snap confinement.
- Downloaded PID m002x5tf successfully from the installed snap to /root/get-iplayer-downloads4:
  Shipping_Forecast_-_2026-06-06_m002x5tf_original.m4a, 33,976,921 bytes

@jnsgruk please review.